### PR TITLE
PR1: 基本UIを実装（ダミー処理付き）

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,10 +3,101 @@ body {
   margin: 0;
   padding: 0;
   font-family: Arial, Helvetica, sans-serif;
+  background: #f5f7fb;
+  color: #1c2430;
 }
 
-main {
+* {
+  box-sizing: border-box;
+}
+
+.container {
   min-height: 100vh;
   display: grid;
   place-items: center;
+  padding: 24px;
+}
+
+.panel {
+  width: min(720px, 100%);
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+.form {
+  display: grid;
+  gap: 16px;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #ced5e2;
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 14px;
+}
+
+.fieldset {
+  margin: 0;
+  border: 1px solid #ced5e2;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.modes {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.mode-option {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.button {
+  width: fit-content;
+  border: none;
+  border-radius: 8px;
+  background: #2563eb;
+  color: #fff;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: #1d4ed8;
+}
+
+.result {
+  margin-top: 24px;
+}
+
+.result h2 {
+  margin: 0 0 8px;
+}
+
+.result pre {
+  margin: 0;
+  border: 1px solid #ced5e2;
+  border-radius: 8px;
+  background: #f8fafc;
+  padding: 12px;
+  min-height: 84px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,72 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+type Mode = 'summary' | 'bullets' | 'tasks';
+
+const modes: Array<{ label: string; value: Mode }> = [
+  { label: 'summary', value: 'summary' },
+  { label: 'bullets', value: 'bullets' },
+  { label: 'tasks', value: 'tasks' }
+];
+
 export default function Home() {
+  const [text, setText] = useState('');
+  const [mode, setMode] = useState<Mode>('summary');
+  const [result, setResult] = useState('');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    setResult(`Processed result:\n${text}`);
+  };
+
   return (
-    <main>
-      <h1>One Screen AI Tool</h1>
+    <main className="container">
+      <section className="panel">
+        <h1>One Screen AI Tool</h1>
+
+        <form onSubmit={handleSubmit} className="form">
+          <label htmlFor="input-text" className="label">
+            Input text
+          </label>
+          <textarea
+            id="input-text"
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            rows={8}
+            placeholder="文章を入力してください"
+            className="textarea"
+          />
+
+          <fieldset className="fieldset">
+            <legend className="label">Processing mode</legend>
+            <div className="modes">
+              {modes.map((option) => (
+                <label key={option.value} className="mode-option">
+                  <input
+                    type="radio"
+                    name="mode"
+                    value={option.value}
+                    checked={mode === option.value}
+                    onChange={() => setMode(option.value)}
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <button type="submit" className="button">
+            Run
+          </button>
+        </form>
+
+        <section className="result" aria-live="polite">
+          <h2>Result</h2>
+          <pre>{result || 'ここに結果が表示されます。'}</pre>
+        </section>
+      </section>
     </main>
   );
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,14 +1,6 @@
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { FlatCompat } from '@eslint/eslintrc';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTypescript from 'eslint-config-next/typescript';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname
-});
-
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')];
+const eslintConfig = [...nextVitals, ...nextTypescript];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "next": "16.0.7",


### PR DESCRIPTION
### Motivation
- PR1の要件に従い、ワンページの基本UI（入力、モード選択、実行、結果表示）を実装して動作確認するための変更です。

### Description
- `app/page.tsx` をクライアントコンポーネントに変更して、入力テキストの状態管理、`summary|bullets|tasks` のラジオ選択、`Run` ボタン押下時にダミー出力 (`Processed result:\n<入力テキスト>`) を返すローカル処理を追加しました。
- `app/globals.css` にレイアウト／フォーム／結果表示用のスタイルを追加して UI を整えました。
- `eslint.config.mjs` を `eslint-config-next` の推奨エクスポート形式に差し替え、`package.json` の `lint` スクリプトを `eslint .` に変更してローカル lint 実行が安定するようにしました。
- 変更ファイルは `app/page.tsx`, `app/globals.css`, `eslint.config.mjs`, `package.json` です。

### Testing
- `npm run lint`（実体は `eslint .`）を実行して問題なく終了しました。✅
- `npm run build` を実行してビルドが成功することを確認しました。✅
- `npm run dev` 起動後に Playwright スクリプトでブラウザ操作（入力、モード選択、`Run` 押下）とスクリーンショット取得を行い UI の動作を確認しました。✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad52d91c8832fb1f29ea6cbb18676)