### PR TITLE
PR3: /api/agent を OpenAI 連携に置換（AI連携）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pnpm-debug.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Next.js（App Router）+ TypeScript で構成した最小構成のプロジェクトです。
 
+## 環境変数
+
+`.env.local` を作成し、以下を設定してください。
+
+```bash
+OPENAI_API_KEY=your_api_key
+```
+
+サンプルは `.env.example` を参照してください。
+
 ## ローカル起動方法
 
 ```bash

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -9,6 +9,13 @@ type AgentRequestBody = {
 
 type OpenAIResponse = {
   output_text?: string;
+  output?: Array<{
+    type?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+    }>;
+  }>;
 };
 
 const modeSet: Set<Mode> = new Set(['summary', 'bullets', 'tasks']);
@@ -57,12 +64,17 @@ const requestAiResult = async (text: string, mode: Mode): Promise<string> => {
   }
 
   const data = (await response.json()) as OpenAIResponse;
+  const fallbackText = data.output
+    ?.flatMap((item) => item.content ?? [])
+    .find((content) => content.type === 'output_text' && typeof content.text === 'string')
+    ?.text;
+  const resultText = typeof data.output_text === 'string' ? data.output_text : fallbackText;
 
-  if (typeof data.output_text !== 'string' || data.output_text.trim().length === 0) {
+  if (typeof resultText !== 'string' || resultText.trim().length === 0) {
     throw new Error('OpenAI API returned an unexpected response.');
   }
 
-  return data.output_text.trim();
+  return resultText.trim();
 };
 
 export async function POST(request: Request) {

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -7,21 +7,62 @@ type AgentRequestBody = {
   mode?: unknown;
 };
 
+type OpenAIResponse = {
+  output_text?: string;
+};
+
 const modeSet: Set<Mode> = new Set(['summary', 'bullets', 'tasks']);
 
-const processText = (text: string, mode: Mode): string => {
-  const trimmedText = text.trim();
+const modePrompts: Record<Mode, string> = {
+  summary: '次の文章を簡潔に要約してください。',
+  bullets: '次の文章を箇条書きに整理してください。',
+  tasks: '次の文章から実行すべきタスクを抽出してください。'
+};
 
-  switch (mode) {
-    case 'summary':
-      return `Summary: ${trimmedText}`;
-    case 'bullets':
-      return `- item: ${trimmedText}`;
-    case 'tasks':
-      return `- TODO: ${trimmedText}`;
-    default:
-      return trimmedText;
+const buildUserPrompt = (text: string, mode: Mode): string => {
+  return `${modePrompts[mode]}\n\n---\n${text.trim()}\n---`;
+};
+
+const requestAiResult = async (text: string, mode: Mode): Promise<string> => {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not set.');
   }
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'gpt-4.1-mini',
+      input: [
+        {
+          role: 'system',
+          content: 'あなたは日本語でテキスト処理を行うアシスタントです。必ず日本語で回答してください。'
+        },
+        {
+          role: 'user',
+          content: buildUserPrompt(text, mode)
+        }
+      ]
+    })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`OpenAI API request failed: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as OpenAIResponse;
+
+  if (typeof data.output_text !== 'string' || data.output_text.trim().length === 0) {
+    throw new Error('OpenAI API returned an unexpected response.');
+  }
+
+  return data.output_text.trim();
 };
 
 export async function POST(request: Request) {
@@ -46,7 +87,14 @@ export async function POST(request: Request) {
     );
   }
 
-  const result = processText(text, mode as Mode);
-
-  return NextResponse.json({ result }, { status: 200 });
+  try {
+    const result = await requestAiResult(text, mode as Mode);
+    return NextResponse.json({ result }, { status: 200 });
+  } catch (error) {
+    console.error('[POST /api/agent] AI processing failed.', error);
+    return NextResponse.json(
+      { error: 'AI processing failed. Please try again later.' },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
### Motivation
- ダミー処理だった `/api/agent` を実際の AI 処理に置き換え、入力テキストに対して `summary`/`bullets`/`tasks` の各モードで実用的な出力を返すようにするため。 

### Description
- `app/api/agent/route.ts` を更新し、各モード向けの日本語プロンプトを追加してサーバー側から OpenAI Responses API (`POST https://api.openai.com/v1/responses`) を呼び出す実装に置き換えました。 
- サーバー側で `OPENAI_API_KEY` を `process.env.OPENAI_API_KEY` から読み込み、不在時や API エラー、想定外レスポンス時のハンドリングを追加しました。 
- レスポンスパース時は `output_text` を期待し、空や不正な場合はエラーとして扱うようにしました。 
- `.env.example` を追加して `OPENAI_API_KEY` の雛形を用意し、`README.md` に環境変数設定手順を追記、さらに `.gitignore` に `!.env.example` を追加してサンプル env を追跡するように変更しました。 

### Testing
- `npm run lint` を実行して成功しました。 
- `npm run build` を実行して成功し、ビルド時に `/api/agent` ルートが正しく組み込まれることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abcdecbf40832fadf78ce022a65bdd)