### PR TITLE
OpenAIレスポンス形状の違いを考慮して /api/agent の解析を修正

### DIFF
--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -9,6 +9,13 @@ type AgentRequestBody = {
 
 type OpenAIResponse = {
   output_text?: string;
+  output?: Array<{
+    type?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+    }>;
+  }>;
 };
 
 const modeSet: Set<Mode> = new Set(['summary', 'bullets', 'tasks']);
@@ -57,12 +64,17 @@ const requestAiResult = async (text: string, mode: Mode): Promise<string> => {
   }
 
   const data = (await response.json()) as OpenAIResponse;
+  const fallbackText = data.output
+    ?.flatMap((item) => item.content ?? [])
+    .find((content) => content.type === 'output_text' && typeof content.text === 'string')
+    ?.text;
+  const resultText = typeof data.output_text === 'string' ? data.output_text : fallbackText;
 
-  if (typeof data.output_text !== 'string' || data.output_text.trim().length === 0) {
+  if (typeof resultText !== 'string' || resultText.trim().length === 0) {
     throw new Error('OpenAI API returned an unexpected response.');
   }
 
-  return data.output_text.trim();
+  return resultText.trim();
 };
 
 export async function POST(request: Request) {


### PR DESCRIPTION
### Motivation
- Vercel のログで `POST /api/agent` が `OpenAI API returned an unexpected response.` によって 500 を返しており、原因はレスポンスをトップレベルの `output_text` のみで期待していたため、実際に返るネストされた `output[].content[]` を拾えていなかったことです。 

### Description
- `app/api/agent/route.ts` の `OpenAIResponse` 型に `output` 配列の形を追加しました。 
- ネストされた `output[].content[].text` から `output_text` をフォールバック抽出するロジックを追加し、トップレベルの `output_text` がない場合に使うようにしました。 
- 抽出結果を `resultText` として統一し、既存の空文字チェックとエラーハンドリングは維持しています。 
- 修正をコミットして PR を作成しました。 

### Testing
- `npm run lint` を実行して成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac1ca6e9d0832f8ee878d75358471d)