### PR TITLE
テキスト入力欄にブラウザ音声入力を追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -101,3 +101,24 @@ h1 {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+
+.voice-input-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.secondary-button {
+  background: #475569;
+}
+
+.secondary-button:hover {
+  background: #334155;
+}
+
+.voice-status {
+  font-size: 13px;
+  color: #334155;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
+import { FormEvent, useEffect, useRef, useState } from 'react';
 
 type Mode = 'summary' | 'bullets' | 'tasks';
 
@@ -10,6 +10,45 @@ type AgentSuccessResponse = {
 
 type AgentErrorResponse = {
   error?: string;
+};
+
+type SpeechRecognitionAlternative = {
+  transcript: string;
+};
+
+type SpeechRecognitionResult = {
+  0: SpeechRecognitionAlternative;
+};
+
+type SpeechRecognitionResultList = {
+  0: SpeechRecognitionResult;
+};
+
+type SpeechRecognitionEvent = {
+  results: SpeechRecognitionResultList;
+};
+
+type SpeechRecognitionErrorEvent = {
+  error: string;
+};
+
+type SpeechRecognitionInstance = {
+  lang: string;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onstart: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onend: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+};
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionInstance;
+
+type ExtendedWindow = Window & {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
 };
 
 const modes: Array<{ label: string; value: Mode }> = [
@@ -24,6 +63,83 @@ export default function Home() {
   const [result, setResult] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+  const [isSpeechSupported, setIsSpeechSupported] = useState(false);
+  const [isListening, setIsListening] = useState(false);
+  const [speechError, setSpeechError] = useState('');
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const supported =
+      'SpeechRecognition' in window ||
+      'webkitSpeechRecognition' in (window as ExtendedWindow);
+    setIsSpeechSupported(supported);
+
+    return () => {
+      recognitionRef.current?.stop();
+      recognitionRef.current = null;
+    };
+  }, []);
+
+  const handleVoiceInput = () => {
+    setSpeechError('');
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (isListening) {
+      recognitionRef.current?.stop();
+      return;
+    }
+
+    const extendedWindow = window as ExtendedWindow;
+    const SpeechRecognitionApi =
+      extendedWindow.SpeechRecognition || extendedWindow.webkitSpeechRecognition;
+
+    if (!SpeechRecognitionApi) {
+      setSpeechError('このブラウザでは音声入力を利用できません。');
+      return;
+    }
+
+    const recognition = new SpeechRecognitionApi();
+    recognition.lang = 'ja-JP';
+    recognition.interimResults = false;
+    recognition.maxAlternatives = 1;
+
+    recognition.onstart = () => {
+      setIsListening(true);
+    };
+
+    recognition.onerror = (event) => {
+      setSpeechError(`音声入力エラー: ${event.error}`);
+    };
+
+    recognition.onresult = (event) => {
+      const transcript = event.results[0]?.[0]?.transcript ?? '';
+
+      if (transcript) {
+        setText((previousText) => {
+          if (!previousText.trim()) {
+            return transcript;
+          }
+
+          return `${previousText}\n${transcript}`;
+        });
+      }
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+      recognitionRef.current = null;
+    };
+
+    recognitionRef.current = recognition;
+    recognition.start();
+  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -81,6 +197,26 @@ export default function Home() {
             placeholder="文章を入力してください"
             className="textarea"
           />
+
+          <div className="voice-input-row">
+            <button
+              type="button"
+              onClick={handleVoiceInput}
+              className="button secondary-button"
+              disabled={!isSpeechSupported || isLoading}
+            >
+              {isListening ? '音声入力を停止' : '音声入力を開始'}
+            </button>
+            <span className="voice-status" role="status" aria-live="polite">
+              {!isSpeechSupported
+                ? 'お使いのブラウザは音声入力に未対応です。'
+                : isListening
+                  ? '音声を認識中です…'
+                  : 'マイクで日本語の音声入力ができます。'}
+            </span>
+          </div>
+
+          {speechError ? <p role="alert">{speechError}</p> : null}
 
           <fieldset className="fieldset">
             <legend className="label">Processing mode</legend>


### PR DESCRIPTION
### Motivation
- ユーザがキーボード入力の代わりに日本語音声でテキストを入力できるようにするための機能追加です。
- 既存の単一画面設計に沿って、クライアント側のみで動作する最小限の実装を目指しました。

### Description
- クライアント側の `app/page.tsx` に Web Speech API（`SpeechRecognition` / `webkitSpeechRecognition`）ラッパーを追加し、日本語（`ja-JP`）の音声認識を行う `handleVoiceInput` を実装しました。
- テキストエリア横に「音声入力を開始／停止」ボタンと状態表示（未対応・認識中など）を追加し、認識結果を既存の入力テキストに追記するようにしました。
- ブラウザ未対応や認識エラー時のメッセージ表示、認識中の制御、API処理中はボタンを無効化する等のエラーハンドリングを追加しました。
- 見た目調整のため `app/globals.css` にボタンとステータス表示のスタイルを追加しました。

### Testing
- 実行した自動検証は `npm run lint` で実行し成功しました。
- ビルド検証として `npm run build` を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc0d5fc1c832fa3257288845f9ffe)