### PR TITLE
test: E2Eに正常操作の送信・結果表示ケースを追加

### DIFF
--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -24,3 +24,32 @@ test('実行時にAPIエラーが表示される', async ({ page }) => {
       .filter({ hasText: 'Error: AI processing failed. Please try again later.' })
   ).toBeVisible();
 });
+
+test('入力内容とモードを送信して結果が表示される', async ({ page }) => {
+  const inputText = '来週の開発タスクを整理してください';
+
+  await page.route('**/api/agent', async (route) => {
+    const requestBody = route.request().postDataJSON();
+
+    expect(requestBody).toEqual({
+      text: inputText,
+      mode: 'tasks'
+    });
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        result: '- API仕様を確認する\n- テストを追加する'
+      })
+    });
+  });
+
+  await page.goto('/');
+  await page.getByLabel('Input text').fill(inputText);
+  await page.getByRole('radio', { name: 'tasks' }).check();
+  await page.getByRole('button', { name: 'Run' }).click();
+
+  await expect(page.getByText('- API仕様を確認する\n- テストを追加する')).toBeVisible();
+  await expect(page.getByRole('alert')).toHaveCount(0);
+});


### PR DESCRIPTION
### Motivation
- E2Eテストに正常系カバレッジが不足しており、入力からAPI送信および結果表示までの一連の動作を検証するために追加しました。

### Description
- `tests/e2e/home.spec.ts` に新しいテスト `入力内容とモードを送信して結果が表示される` を追加しました。
- テスト内で `page.route('**/api/agent')` を使い `/api/agent` をモックしてリクエストボディの `text` と `mode` を検証しています。
- モックは成功レスポンス `{ result: '...' }` を返し、ページ上で結果が表示されエラー表示がないことを確認しています。

### Testing
- `npm run lint` は成功しました。
- `npm run test:e2e -- tests/e2e/home.spec.ts` はこの環境で `playwright: not found` のため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4abd5c758832fb6c82d7db78b2ca2)