### PR TITLE
docs: add issue draft to fix Playwright not found in E2E

### DIFF
--- a/docs/issues/2026-03-30-fix-playwright-not-found-for-e2e.md
+++ b/docs/issues/2026-03-30-fix-playwright-not-found-for-e2e.md
@@ -1,0 +1,29 @@
+# Issue: `npm run test:e2e` で `playwright: not found` が発生する問題を解消する
+
+## 背景
+PR #11 のレビューコメント（https://github.com/rugby3m1d/one-screen-ai-tool/pull/11#issuecomment-4056905872）で、以下のエラーにより E2E テストが実行できない状態です。
+
+- ⚠️ `npm run test:e2e`（この環境では `playwright: not found` のため実行不可）
+
+CI / ローカル環境のどちらでも、`playwright` バイナリが確実に利用可能になる導線が不足している可能性があります。
+
+## 問題
+`npm run test:e2e` 実行時に Playwright の実行バイナリが見つからず、E2E テストが開始されない。
+
+## 期待する状態
+- `npm run test:e2e` がクリーン環境（CI 含む）で再現性高く実行できる
+- セットアップ手順に沿えば `playwright: not found` が発生しない
+
+## 対応案
+1. `@playwright/test` が `devDependencies` に存在するかを確認し、未設定なら追加する
+2. 初回セットアップ手順として `npx playwright install --with-deps`（または CI 用の等価手順）を README に明記する
+3. CI のワークフローで Playwright のブラウザインストール工程を追加する
+4. 必要に応じて `test:e2e` スクリプトを見直し、`npx playwright test` で実行されることを保証する
+
+## 受け入れ条件
+- [ ] クリーン環境で `npm ci && npx playwright install --with-deps && npm run test:e2e` が成功する
+- [ ] CI 上で E2E ジョブが成功する
+- [ ] README に E2E 実行の前提条件が追記されている
+
+## 補足
+本 issue は「テスト自体の不具合修正」ではなく、「E2E 実行基盤（依存関係・セットアップ・CI）を安定化する」ことを主目的とする。


### PR DESCRIPTION
### Motivation
- PR #11 のレビューで `npm run test:e2e` が `playwright: not found` により実行できなかったため、E2E 実行基盤（依存・セットアップ・CI）修正を追跡する Issue 下書きを作成しました。

### Description
- 新規ファイル `docs/issues/2026-03-30-fix-playwright-not-found-for-e2e.md` を追加し、問題の背景、期待する状態、対応案（`@playwright/test` の確認、`npx playwright install --with-deps` の明記、CI へのブラウザインストール追加、`test:e2e` スクリプト見直し）と受け入れ条件を記載してコミットしました。

### Testing
- ドキュメントのみの変更のため自動化テストは実行しておらず、該当の変更に関するテストはありません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb00e37d9c832fbaef5a658bb98dd2)