### PR TITLE
docs: CodexでPlaywright E2Eを実行しないルールを追加

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -7,6 +7,7 @@
 - Prefer one feature per pull request.
 - Call external AI APIs from server-side code only.
 - Never expose API keys to client-side code.
+- Do not run Playwright E2E tests in Codex (`npm run test:e2e`); E2E execution is delegated to CI/CD.
 
 ## Specification & Design
 


### PR DESCRIPTION
### Motivation
- `issue #19` で報告された Codex 実行環境での Playwright バイナリ不足に起因する E2E 実行失敗を回避するため、Codex 上で `npm run test:e2e` を実行しない運用を明文化しました.

### Description
- `Agents.md` の `Permanent Rules` に「Codexでは Playwright E2E テスト（`npm run test:e2e`）を実行しない; E2E は CI/CD に委譲する」という一行を追加しました.

### Testing
- 実行した自動化コマンドは `nl -ba Agents.md`、`git status --short`、および `git add` と `git commit` の操作で、いずれも成功しました.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfa4233fc832f9e01d1e12eb094b1)